### PR TITLE
Silence -Wshift-op-parentheses

### DIFF
--- a/powerpc_isa.cpp
+++ b/powerpc_isa.cpp
@@ -362,7 +362,7 @@ inline int ceil(int value, int divisor) {
 inline unsigned int rotl(unsigned int reg,unsigned int n) {
   unsigned int tmp1=reg;
   unsigned int tmp2=reg;
-  unsigned int rotated=(tmp1 << n) | (tmp2 >> 32-n);
+  unsigned int rotated=(tmp1 << n) | (tmp2 >> (32-n));
  
   return(rotated);
 }


### PR DESCRIPTION
The Apple clang include the -Wshift-op-parentheses by default.
This PR only explicit the precedence of minus over shift.
